### PR TITLE
Fix Collared Report layout

### DIFF
--- a/workflows/mep-collared_report/layout.json
+++ b/workflows/mep-collared_report/layout.json
@@ -2,20 +2,20 @@
   { "i": "0", "x": 0, "y": 0,  "widget_id": 0, "w": 2,  "h": 3,  "minW": 1, "minH": 3, "static": false },
   { "i": "1", "x": 2, "y": 0,  "widget_id": 1, "w": 2,  "h": 3,  "minW": 1, "minH": 3, "static": false },
   { "i": "2", "x": 4, "y": 0,  "widget_id": 2, "w": 2,  "h": 3,  "minW": 1, "minH": 3, "static": false },
-
   { "i": "3", "x": 6, "y": 0,  "widget_id": 3, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
-  { "i": "4", "x": 8, "y": 13, "widget_id": 4, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
-  { "i": "5", "x": 0, "y": 23, "widget_id": 5, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
-  { "i": "6", "x": 2, "y": 33, "widget_id": 6, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
-  { "i": "7", "x": 4, "y": 43, "widget_id": 7, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
-  { "i": "8", "x": 6, "y": 53, "widget_id": 8, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
+  { "i": "4", "x": 8, "y": 0, "widget_id": 4, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
+  
+  { "i": "5", "x": 0, "y": 3, "widget_id": 5, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
+  { "i": "6", "x": 2, "y": 3, "widget_id": 6, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
+  { "i": "7", "x": 4, "y": 3, "widget_id": 7, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
+  { "i": "8", "x": 6, "y": 3, "widget_id": 8, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
+  { "i": "9",  "x": 8, "y": 3,  "widget_id": 9, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
 
-  { "i": "9",  "x": 8, "y": 63,  "widget_id": 9, "w": 2, "h": 3, "minW": 1, "minH": 3, "static": false },
-  { "i": "10", "x": 0, "y": 73, "widget_id": 10, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
-  { "i": "11", "x": 5, "y": 83, "widget_id": 11, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
-  { "i": "12", "x": 0, "y": 93, "widget_id": 12, "w": 5, "h":10, "minW": 4, "minH": 8, "static": false },
-  { "i": "13", "x": 5, "y": 103, "widget_id": 13, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
-  { "i": "14", "x": 0, "y": 113, "widget_id": 14, "w": 15, "h": 10, "minW": 5, "minH": 8, "static": false },
-  { "i": "15", "x": 0, "y": 123, "widget_id": 15, "w": 15, "h": 12, "minW": 5, "minH": 8, "static": false },
-  { "i": "16", "x": 0, "y": 133, "widget_id": 16, "w": 15, "h": 10, "minW": 5, "minH": 8, "static": false }
+  { "i": "10", "x": 0, "y": 6, "widget_id": 10, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
+  { "i": "11", "x": 5, "y": 6, "widget_id": 11, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
+  { "i": "12", "x": 0, "y": 16, "widget_id": 12, "w": 5, "h":10, "minW": 4, "minH": 8, "static": false },
+  { "i": "13", "x": 5, "y": 16, "widget_id": 13, "w": 5, "h": 10, "minW": 4, "minH": 8, "static": false },
+  { "i": "14", "x": 0, "y": 26, "widget_id": 14, "w": 15, "h": 10, "minW": 5, "minH": 8, "static": false },
+  { "i": "15", "x": 0, "y": 36, "widget_id": 15, "w": 15, "h": 10, "minW": 5, "minH": 8, "static": false },
+  { "i": "16", "x": 0, "y": 46, "widget_id": 16, "w": 15, "h": 10, "minW": 5, "minH": 8, "static": false }
 ]


### PR DESCRIPTION
## :earth_americas: Summary
Closes #23

## :package: Proposed Changes
- Fixes the y alignment of widgets in the layout
- Also noticed the Collared Subject Plot was set to be slightly taller than the other plots (height 12 vs height 10) so have aligned this 

## 📋 Checklist
- [ ] Unit tests updated (if applicable)
- [ ] test-cases.yaml updated (if applicable)
- [ ] rjsf file changes validated
- [ ] Choose ONE label to run workflow tests:
    - `test:local` - Run workflow tests with local build 
    - `test:published` - Run workflow tests with published packages only on MacOS, Linux and Windows

## :rocket: Checklist for Publishing Workflows
(Only complete if this PR is preparing workflows for customer handover)
- [ ] Task library published to prefix
- [ ] User guide updated

