### PR TITLE
Handle tuples in `gdf_to_geojson`

### DIFF
--- a/src/ecoscope-workflows-ext-mep/ecoscope_workflows_ext_mep/tasks/_persist.py
+++ b/src/ecoscope-workflows-ext-mep/ecoscope_workflows_ext_mep/tasks/_persist.py
@@ -35,6 +35,18 @@ def gdf_to_geojson(
         filename = hashlib.sha256(hash_input).hexdigest()[:7]
 
     buffer = io.BytesIO()
-    gdf = gpd.GeoDataFrame(df)
+    gdf = gpd.GeoDataFrame(df.copy())
+ 
+    # Handle tuple columns - in practice these are only our color columns and should serialize as lists
+    def _is_tuple_column(series: pd.Series) -> bool:
+        values = series.dropna()
+        return len(values) > 0 and all(isinstance(v, tuple) for v in values)
+
+    for col in gdf.select_dtypes(include="object").columns:
+        if col == gdf.geometry.name:
+            continue
+        if _is_tuple_column(gdf[col]):
+            gdf[col] = gdf[col].map(lambda v: list(v) if isinstance(v, tuple) else v)
+
     gdf.to_file(buffer, driver="GeoJSON")
     return _persist_text(buffer.getvalue().decode("utf-8"), root_path, f"{filename}.geojson")

--- a/src/ecoscope-workflows-ext-mep/ecoscope_workflows_ext_mep/tasks/_persist.py
+++ b/src/ecoscope-workflows-ext-mep/ecoscope_workflows_ext_mep/tasks/_persist.py
@@ -36,7 +36,7 @@ def gdf_to_geojson(
 
     buffer = io.BytesIO()
     gdf = gpd.GeoDataFrame(df.copy())
- 
+
     # Handle tuple columns - in practice these are only our color columns and should serialize as lists
     def _is_tuple_column(series: pd.Series) -> bool:
         values = series.dropna()

--- a/src/ecoscope-workflows-ext-mep/tests/tasks/test_persist.py
+++ b/src/ecoscope-workflows-ext-mep/tests/tasks/test_persist.py
@@ -61,7 +61,7 @@ def test_tuple_column_with_nan_values(tmp_path):
         data = json.load(f)
     colors = [f["properties"]["color"] for f in data["features"]]
     labels = [f["properties"]["label"] for f in data["features"]]
-    assert colors[0] == [[255, 0, 0], None, [0, 0, 255]]
+    assert colors == [[255, 0, 0], None, [0, 0, 255]]
     assert labels == ["a", "b", "c"]
 
 

--- a/src/ecoscope-workflows-ext-mep/tests/tasks/test_persist.py
+++ b/src/ecoscope-workflows-ext-mep/tests/tasks/test_persist.py
@@ -1,0 +1,81 @@
+import json
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from shapely.geometry import Point
+
+from ecoscope_workflows_ext_mep.tasks._persist import gdf_to_geojson
+
+
+@pytest.fixture
+def sample_gdf():
+    return gpd.GeoDataFrame(
+        {"value": [1, 2, 3], "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)]},
+        crs="EPSG:4326",
+    )
+
+
+def test_basic_serialization(sample_gdf, tmp_path):
+    path = gdf_to_geojson(df=sample_gdf, root_path=str(tmp_path))
+    assert path.endswith(".geojson")
+    with open(path) as f:
+        data = json.load(f)
+    assert data["type"] == "FeatureCollection"
+    assert len(data["features"]) == 3
+
+
+def test_custom_filename(sample_gdf, tmp_path):
+    path = gdf_to_geojson(df=sample_gdf, root_path=str(tmp_path), filename="my_output")
+    assert path.endswith("my_output.geojson")
+
+
+def test_tuple_columns_serialized_as_lists(tmp_path):
+    gdf = gpd.GeoDataFrame(
+        {
+            "color": [(255, 0, 0), (0, 255, 0), (0, 0, 255)],
+            "label": ["a", "b", "c"],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        crs="EPSG:4326",
+    )
+    path = gdf_to_geojson(df=gdf, root_path=str(tmp_path))
+    with open(path) as f:
+        data = json.load(f)
+    colors = [f["properties"]["color"] for f in data["features"]]
+    labels = [f["properties"]["label"] for f in data["features"]]
+    assert colors == [[255, 0, 0], [0, 255, 0], [0, 0, 255]]
+    assert labels == ["a", "b", "c"]
+
+
+def test_tuple_column_with_nan_values(tmp_path):
+    gdf = gpd.GeoDataFrame(
+        {
+            "color": [(255, 0, 0), None, (0, 0, 255)],
+            "label": ["a", "b", "c"],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        crs="EPSG:4326",
+    )
+    path = gdf_to_geojson(df=gdf, root_path=str(tmp_path))
+    with open(path) as f:
+        data = json.load(f)
+    colors = [f["properties"]["color"] for f in data["features"]]
+    labels = [f["properties"]["label"] for f in data["features"]]
+    assert colors[0] == [[255, 0, 0], None, [0,0,255]]
+    assert labels == ["a", "b", "c"]
+
+
+def test_deterministic_hash_for_same_df(sample_gdf, tmp_path):
+    path1 = gdf_to_geojson(df=sample_gdf, root_path=str(tmp_path))
+    path2 = gdf_to_geojson(df=sample_gdf, root_path=str(tmp_path))
+    assert path1 == path2
+
+
+def test_different_hash_for_different_df(tmp_path):
+    gdf1 = gpd.GeoDataFrame({"value": [1], "geometry": [Point(0, 0)]}, crs="EPSG:4326")
+    gdf2 = gpd.GeoDataFrame({"value": [2], "geometry": [Point(0, 0)]}, crs="EPSG:4326")
+    path1 = gdf_to_geojson(df=gdf1, root_path=str(tmp_path))
+    path2 = gdf_to_geojson(df=gdf2, root_path=str(tmp_path))
+    assert path1 != path2

--- a/src/ecoscope-workflows-ext-mep/tests/tasks/test_persist.py
+++ b/src/ecoscope-workflows-ext-mep/tests/tasks/test_persist.py
@@ -1,8 +1,6 @@
 import json
 
 import geopandas as gpd
-import numpy as np
-import pandas as pd
 import pytest
 from shapely.geometry import Point
 
@@ -63,7 +61,7 @@ def test_tuple_column_with_nan_values(tmp_path):
         data = json.load(f)
     colors = [f["properties"]["color"] for f in data["features"]]
     labels = [f["properties"]["label"] for f in data["features"]]
-    assert colors[0] == [[255, 0, 0], None, [0,0,255]]
+    assert colors[0] == [[255, 0, 0], None, [0, 0, 255]]
     assert labels == ["a", "b", "c"]
 
 


### PR DESCRIPTION
## :earth_americas: Summary
Handles color tuple serialzation by explicitly converting them to lists 

## :package: Proposed Changes
- Updates `gdf_to_geojson` with treatment for tuples in columns
- Adds test coverage for the above task
- This is intended to be a short term bandaid and will circle back with a more holistic fix via the core library 

## 📋 Checklist
- [x] Unit tests updated (if applicable)
- [ ] test-cases.yaml updated (if applicable)
- [ ] rjsf file changes validated
- [ ] Choose ONE label to run workflow tests:
    - `test:local` - Run workflow tests with local build 
    - `test:published` - Run workflow tests with published packages only on MacOS, Linux and Windows

## :rocket: Checklist for Publishing Workflows
(Only complete if this PR is preparing workflows for customer handover)
- [ ] Task library published to prefix
- [ ] User guide updated

